### PR TITLE
fix: use padok-team renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+      "local>padok-team/renovate-config"
   ]
 }


### PR DESCRIPTION
It includes ":semanticPrefixFix" which tells renovate to use "fix" instead of "deps" for its commit message.

This is required to trigger Release Please for new releases. For example, the
https://github.com/padok-team/terraform-google-serviceaccount/pull/18 update did not triggered any release, which is an issue if you want to update your providers